### PR TITLE
Basic functionality for users to set packages as favourites

### DIFF
--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -28,6 +28,8 @@ defmodule Hexpm.Accounts.User do
     has_many :audit_logs, AuditLog
     has_many :password_resets, PasswordReset
     has_many :package_reports, Hexpm.Repository.PackageReport
+    has_many :favourite_packages, FavouritePackage
+    has_many :packages, through: [:favourite_packages, :package]
   end
 
   @username_regex ~r"^[a-z0-9_\-\.]+$"

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -537,4 +537,12 @@ defmodule Hexpm.Accounts.Users do
   def has_role(user, role) do
     user != nil and user.role == role
   end
+
+  def add_favourite_package(favourite) do
+    Repo.insert(favourite)
+  end
+
+  def remove_favourite_package(favourite) do
+    Repo.delete_all(FavouritePackage.get(favourite.id))
+  end
 end

--- a/lib/hexpm/repository/favourite_package.ex
+++ b/lib/hexpm/repository/favourite_package.ex
@@ -1,30 +1,30 @@
 defmodule Hexpm.Repository.FavouritePackage do
-    use Hexpm.Schema
+  use Hexpm.Schema
 
-    schema "favourite_packages" do
-        belongs_to :user, User
-        belongs_to :package, Package
+  schema "favourite_packages" do
+    belongs_to :user, User
+    belongs_to :package, Package
 
-        timestamps()
-    end
+    timestamps()
+  end
 
-    def get(favourite) do
-        from(
-            f in FavouritePackage,
-            where: f.id == ^favourite,
-            select: f
-        )
-    end
+  def get(favourite) do
+    from(
+      f in FavouritePackage,
+      where: f.id == ^favourite,
+      select: f
+    )
+  end
 
-    def get_by_username(username) do
-        from(
-          f in FavouritePackage,
-          join: u in assoc(f, :user),
-          join: p in assoc(f, :package),
-          join: r in assoc(p, :repository),
-          preload: [package: {p, repository: r}],
-          where: u.username == ^username,
-          select: f
-        )
-      end
+  def get_by_username(username) do
+    from(
+      f in FavouritePackage,
+      join: u in assoc(f, :user),
+      join: p in assoc(f, :package),
+      join: r in assoc(p, :repository),
+      preload: [package: {p, repository: r}],
+      where: u.username == ^username,
+      select: f
+    )
+  end
 end

--- a/lib/hexpm/repository/favourite_package.ex
+++ b/lib/hexpm/repository/favourite_package.ex
@@ -1,0 +1,30 @@
+defmodule Hexpm.Repository.FavouritePackage do
+    use Hexpm.Schema
+
+    schema "favourite_packages" do
+        belongs_to :user, User
+        belongs_to :package, Package
+
+        timestamps()
+    end
+
+    def get(favourite) do
+        from(
+            f in FavouritePackage,
+            where: f.id == ^favourite,
+            select: f
+        )
+    end
+
+    def get_by_username(username) do
+        from(
+          f in FavouritePackage,
+          join: u in assoc(f, :user),
+          join: p in assoc(f, :package),
+          join: r in assoc(p, :repository),
+          preload: [package: {p, repository: r}],
+          where: u.username == ^username,
+          select: f
+        )
+      end
+end

--- a/lib/hexpm/repository/favourite_packages.ex
+++ b/lib/hexpm/repository/favourite_packages.ex
@@ -1,9 +1,8 @@
 defmodule Hexpm.Repository.FavouritePackages do
-    use Hexpm.Context
-  
-    def get_by_username(username) do
-        FavouritePackage.get_by_username(username)
-        |> Repo.all()
-    end
+  use Hexpm.Context
+
+  def get_by_username(username) do
+    FavouritePackage.get_by_username(username)
+    |> Repo.all()
   end
-  
+end

--- a/lib/hexpm/repository/favourite_packages.ex
+++ b/lib/hexpm/repository/favourite_packages.ex
@@ -1,0 +1,9 @@
+defmodule Hexpm.Repository.FavouritePackages do
+    use Hexpm.Context
+  
+    def get_by_username(username) do
+        FavouritePackage.get_by_username(username)
+        |> Repo.all()
+    end
+  end
+  

--- a/lib/hexpm/shared.ex
+++ b/lib/hexpm/shared.ex
@@ -22,6 +22,8 @@ defmodule Hexpm.Shared do
         Repository.PackageReportRelease,
         Repository.Assets,
         Repository.Download,
+        Repository.FavouritePackage,
+        Repository.FavouritePackages,
         Repository.Install,
         Repository.Installs,
         Repository.Owners,

--- a/lib/hexpm_web/controllers/user_controller.ex
+++ b/lib/hexpm_web/controllers/user_controller.ex
@@ -22,21 +22,43 @@ defmodule HexpmWeb.UserController do
     end
   end
 
+  def toggle_follow(conn, %{"package" => package_name, "repository" => repository}) do
+    user = conn.assigns.current_user
+    current_favourite = FavouritePackages.get_by_username(user.username)
+    package = Packages.get(repository, package_name)
+
+    match = Enum.find(current_favourite, False, fn f -> f.package.id == package.id end)
+
+    if match != False do
+      Users.remove_favourite_package(match)
+    else
+      Users.add_favourite_package(%FavouritePackage{:user => user, :package => package})
+    end
+    
+    conn
+        |> put_flash(:info, "Favourite packages changed")
+        |> redirect(to: Routes.user_path(HexpmWeb.Endpoint, :show, conn.assigns.current_user))
+  end
+
   defp show_user(conn, user) do
-    packages =
+    owned_packages =
       Packages.accessible_user_owned_packages(user, conn.assigns.current_user)
       |> Packages.attach_versions()
 
     public_email = User.email(user, :public)
     gravatar_email = User.email(user, :gravatar)
 
+    favourite_packages = 
+      FavouritePackages.get_by_username(user.username)
+    
     render(
       conn,
       "show.html",
       title: user.username,
       container: "container page user",
       user: user,
-      packages: packages,
+      owned_packages: owned_packages,
+      favourite_packages: favourite_packages,
       public_email: public_email,
       gravatar_email: gravatar_email
     )

--- a/lib/hexpm_web/controllers/user_controller.ex
+++ b/lib/hexpm_web/controllers/user_controller.ex
@@ -34,10 +34,10 @@ defmodule HexpmWeb.UserController do
     else
       Users.add_favourite_package(%FavouritePackage{:user => user, :package => package})
     end
-    
+
     conn
-        |> put_flash(:info, "Favourite packages changed")
-        |> redirect(to: Routes.user_path(HexpmWeb.Endpoint, :show, conn.assigns.current_user))
+    |> put_flash(:info, "Favourite packages changed")
+    |> redirect(to: Routes.user_path(HexpmWeb.Endpoint, :show, conn.assigns.current_user))
   end
 
   defp show_user(conn, user) do
@@ -48,9 +48,8 @@ defmodule HexpmWeb.UserController do
     public_email = User.email(user, :public)
     gravatar_email = User.email(user, :gravatar)
 
-    favourite_packages = 
-      FavouritePackages.get_by_username(user.username)
-    
+    favourite_packages = FavouritePackages.get_by_username(user.username)
+
     render(
       conn,
       "show.html",

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -85,9 +85,8 @@ defmodule HexpmWeb.Router do
 
     get "/users/:username", UserController, :show
     post "/users/me/toggle_follow", UserController, :toggle_follow
-    
+
     get "/orgs/:username", UserController, :show
-    
 
     get "/docs", DocsController, :index
     get "/docs/usage", DocsController, :usage

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -84,8 +84,10 @@ defmodule HexpmWeb.Router do
     get "/dashboard", DashboardController, :index
 
     get "/users/:username", UserController, :show
-
+    post "/users/me/toggle_follow", UserController, :toggle_follow
+    
     get "/orgs/:username", UserController, :show
+    
 
     get "/docs", DocsController, :index
     get "/docs/usage", DocsController, :usage

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -167,12 +167,14 @@ tools = [
         <input type = "hidden" name = "repository" value = "<%= @package.repository.name %>"/>
         <button type = "submit"> Report <%= ViewHelpers.package_name(@package) %> </button>
       </form>
-    <h3>Follow</h3>
+    <%= if ViewHelpers.logged_in?(assigns) do %>
+    <h3>Favourite</h3>
       <%= form_tag(Routes.user_path(Endpoint, :toggle_follow), method: :post) do %>
         <input type = "hidden" name = "package" value = "<%= @package.name %>"/>
         <input type = "hidden" name = "repository" value = "<%= @package.repository.name %>"/>
-        <button type = "submit"> Follow </button>
+        <button type = "submit"> Favourite </button>
       <% end %>
+    <%= end %>
     <h3>Config</h3>
     <%= for {tool, file} <- tools do %>
       <div class="package-snippet">

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -166,7 +166,13 @@ tools = [
         <input type = "hidden" name = "package" value = "<%= @package.name %>"/>
         <input type = "hidden" name = "repository" value = "<%= @package.repository.name %>"/>
         <button type = "submit"> Report <%= ViewHelpers.package_name(@package) %> </button>
-      </a>
+      </form>
+    <h3>Follow</h3>
+      <%= form_tag(Routes.user_path(Endpoint, :toggle_follow), method: :post) do %>
+        <input type = "hidden" name = "package" value = "<%= @package.name %>"/>
+        <input type = "hidden" name = "repository" value = "<%= @package.repository.name %>"/>
+        <button type = "submit"> Follow </button>
+      <% end %>
     <h3>Config</h3>
     <%= for {tool, file} <- tools do %>
       <div class="package-snippet">

--- a/lib/hexpm_web/templates/user/show.html.eex
+++ b/lib/hexpm_web/templates/user/show.html.eex
@@ -7,10 +7,24 @@
     <% else %>
       <h3 class="first-header">Owned packages</h3>
       <ul class="user-package-list">
-        <%= for package <- @packages do %>
+        <%= for package <- @owned_packages do %>
           <li>
             <a href="<%= ViewHelpers.path_for_package(package) %>"><%= ViewHelpers.package_name(package) %></a>
             <%= package.latest_version %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
+    <%= if @favourite_packages == [] do %>
+      <h3>No favourite packages</h3>
+    <% else %>
+      <h3 class="first-header">Favourite packages</h3>
+      <ul class="user-package-list">
+        <%= for favourite <- @favourite_packages do %>
+          <li>
+            <a href="<%= ViewHelpers.path_for_package(favourite.package) %>"><%= ViewHelpers.package_name(favourite.package) %></a>
+            <%= favourite.package.latest_version %>
           </li>
         <% end %>
       </ul>

--- a/priv/repo/migrations/20200617074339_add_favourite_package_table.exs
+++ b/priv/repo/migrations/20200617074339_add_favourite_package_table.exs
@@ -2,19 +2,15 @@ defmodule Hexpm.RepoBase.Migrations.AddFavouritePackageTable do
   use Ecto.Migration
 
   def up() do
-    execute("""
-      CREATE TABLE favourite_packages (
-        id serial PRIMARY KEY,
-        user_id integer REFERENCES users,
-        package_id integer REFERENCES packages,
+    create table(:favourite_packages) do
+      add(:user_id, references(:users), null: false)
+      add(:package_id, references(:packages), null: false)
 
-        updated_at timestamp,
-        inserted_at timestamp
-      )
-    """)
+      timestamps()
+    end
   end
 
   def drop() do
-    execute("DROP TABLE IF EXISTS favourite_packages")
+    drop(table("favourite_packages"))
   end
 end

--- a/priv/repo/migrations/20200617074339_add_favourite_package_table.exs
+++ b/priv/repo/migrations/20200617074339_add_favourite_package_table.exs
@@ -1,0 +1,20 @@
+defmodule Hexpm.RepoBase.Migrations.AddFavouritePackageTable do
+  use Ecto.Migration
+
+  def up() do
+    execute("""
+      CREATE TABLE favourite_packages (
+        id serial PRIMARY KEY,
+        user_id integer REFERENCES users,
+        package_id integer REFERENCES packages,
+
+        updated_at timestamp,
+        inserted_at timestamp
+      )
+    """)
+  end
+
+  def drop() do
+    execute("DROP TABLE IF EXISTS favourite_packages")
+  end
+end


### PR DESCRIPTION
Package show template now displays a **"Favourite" button**, which includes or deletes the package from the user's favourite packages list.

No information is given to the user about which of those two actions, include or delete, will be performed when clicking the button.