### PR TITLE
Add change state control pre and post show report

### DIFF
--- a/lib/hexpm/repository/package_reports.ex
+++ b/lib/hexpm/repository/package_reports.ex
@@ -27,18 +27,24 @@ defmodule Hexpm.Repository.PackageReports do
     |> Repo.one()
   end
 
-  def accept(report, comment) do
-    PackageReport.change_state(report, %{"comment" => comment, "state" => "accepted"})
+  def accept(report_id, comment) do
+    PackageReport.get(report_id)
+    |> Repo.one()
+    |> PackageReport.change_state(%{"state" => "accepted"})
     |> Repo.update()
   end
 
-  def reject(report, comment) do
-    PackageReport.change_state(report, %{"comment" => comment, "state" => "rejected"})
+  def reject(report_id, comment) do
+    PackageReport.get(report_id)
+    |> Repo.one()
+    |> PackageReport.change_state(%{"state" => "rejected"})
     |> Repo.update()
   end
 
-  def solve(report, comment) do
-    PackageReport.change_state(report, %{"comment" => comment, "state" => "solved"})
+  def solve(report_id, comment) do
+    PackageReport.get(report_id)
+    |> Repo.one()
+    |> PackageReport.change_state(%{"state" => "solved"})
     |> Repo.update()
   end
 end

--- a/lib/hexpm_web/controllers/package_report_controller.ex
+++ b/lib/hexpm_web/controllers/package_report_controller.ex
@@ -80,7 +80,6 @@ defmodule HexpmWeb.PackageReportController do
       |> put_status(400)
       |> redirect(to: Routes.package_path(HexpmWeb.Endpoint, :index))
     else
-
       render(
         conn,
         "show.html",
@@ -151,7 +150,6 @@ defmodule HexpmWeb.PackageReportController do
   defp valid_state_change(new, %{state: "to_accept"}), do: new in ["accepted", "rejected"]
   defp valid_state_change(new, %{state: "accepted"}), do: new in ["solved", "rejected"]
   defp valid_state_change(new, _), do: false
-
 
   defp slice_releases(releases, requirement) do
     rs =

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -128,6 +128,7 @@ defmodule HexpmWeb.Router do
     get "/reports/:id", PackageReportController, :show
     post "/reports/:id/accept", PackageReportController, :accept_report
     post "/reports/:id/reject", PackageReportController, :reject_report
+    post "/reports/:id/solve", PackageReportController, :solve_report
   end
 
   scope "/dashboard", HexpmWeb.Dashboard do

--- a/lib/hexpm_web/templates/package_report/_moderator_pannel.html.eex
+++ b/lib/hexpm_web/templates/package_report/_moderator_pannel.html.eex
@@ -1,23 +1,23 @@
 <div style="background-color: coral; width: 300px">
   <h2>Moderator pannel </h2>
-  <%= if @no_posible_transition do %>
-    <%= @no_possible_transition_msg %>
+  <%= if @report.state in ["solved","rejected"] do %>
+    <p>"This report's state is final and can not be changed"</p>
   <% else %>
-    <%= if @show_accept do%>
-      <%= form_tag Routes.package_report_path(Endpoint, :accept_report, @report_id) do %>
-        <input type="hidden" name="report_id" value="<%= @report_id %>"/>
+    <%= if @report.state in ["to_accept"] do%>
+      <%= form_tag Routes.package_report_path(Endpoint, :accept_report, @report.id) do %>
+        <input type="hidden" name="report_id" value="<%= @report.id %>"/>
         <input type="submit" name="operation" value="Accept"/>
       <% end %>
     <% end %>
-    <%= if @show_reject do%>
-      <%= form_tag Routes.package_report_path(Endpoint, :reject_report, @report_id) do %>
-        <input type="hidden" name="report_id" value="<%= @report_id %>"/>
+    <%= if @report.state in ["to_accept","accepted"] do%>
+      <%= form_tag Routes.package_report_path(Endpoint, :reject_report, @report.id) do %>
+        <input type="hidden" name="report_id" value="<%= @report.id %>"/>
         <input type="submit" name="operation" value="Reject"/>
       <% end %>
     <% end %>
-    <%= if @show_solve do %>
-      <%= form_tag Routes.package_report_path(Endpoint, :solve_report, @report_id) do %>
-        <input type="hidden" name="report_id" value="<%= @report_id %>"/>
+    <%= if @report.state in ["accepted"] do %>
+      <%= form_tag Routes.package_report_path(Endpoint, :solve_report, @report.id) do %>
+        <input type="hidden" name="report_id" value="<%= @report.id %>"/>
         <input type="submit" name="operation" value="Solve"/>
       <% end %>
     <% end %>

--- a/lib/hexpm_web/templates/package_report/_moderator_pannel.html.eex
+++ b/lib/hexpm_web/templates/package_report/_moderator_pannel.html.eex
@@ -1,13 +1,25 @@
 <div style="background-color: coral; width: 300px">
   <h2>Moderator pannel </h2>
-  <%= form_tag Routes.package_report_path(Endpoint, :accept_report, @report_id) do %>
-    <input type="hidden" name="report_id" value="<%= @report_id %>"/>
-    <textarea name="comment"> </textarea>
-    <input type="submit" name="operation" value="Accept"/>
-  <% end %>
-  <%= form_tag Routes.package_report_path(Endpoint, :reject_report, @report_id) do %>
-    <input type="hidden" name="report_id" value="<%= @report_id %>"/>
-    <textarea name="comment"> </textarea>
-    <input type="submit" name="operation" value="Reject"/>
+  <%= if @no_posible_transition do %>
+    <%= @no_possible_transition_msg %>
+  <% else %>
+    <%= if @show_accept do%>
+      <%= form_tag Routes.package_report_path(Endpoint, :accept_report, @report_id) do %>
+        <input type="hidden" name="report_id" value="<%= @report_id %>"/>
+        <input type="submit" name="operation" value="Accept"/>
+      <% end %>
+    <% end %>
+    <%= if @show_reject do%>
+      <%= form_tag Routes.package_report_path(Endpoint, :reject_report, @report_id) do %>
+        <input type="hidden" name="report_id" value="<%= @report_id %>"/>
+        <input type="submit" name="operation" value="Reject"/>
+      <% end %>
+    <% end %>
+    <%= if @show_solve do %>
+      <%= form_tag Routes.package_report_path(Endpoint, :solve_report, @report_id) do %>
+        <input type="hidden" name="report_id" value="<%= @report_id %>"/>
+        <input type="submit" name="operation" value="Solve"/>
+      <% end %>
+    <% end %>
   <% end %>
 </div>

--- a/lib/hexpm_web/templates/package_report/_owner_panel.html.eex
+++ b/lib/hexpm_web/templates/package_report/_owner_panel.html.eex
@@ -1,8 +1,0 @@
-<div style="background-color: cyan; width: 300px">
-  <h2>Owner pannel </h2>
-  <%= form_tag Routes.package_report_path(Endpoint, :owner_review, @report_id) do %>
-    <input type="hidden" name="report_id" value="<%= @report_id %>"/>
-    <textarea name="comment"> </textarea>
-    <input type="submit" name="operation" value="Solve"/>
-  <% end %>
-</div>

--- a/lib/hexpm_web/templates/package_report/show.html.eex
+++ b/lib/hexpm_web/templates/package_report/show.html.eex
@@ -9,7 +9,7 @@
 <p> Report status: <%= @report.state %>
 
 <%= if @for_moderator do %>
-    <%= render "_moderator_pannel.html", report_id: @report.id, author: @report.author, show_accept: @show_accept, show_reject: @show_reject, show_solve: @show_solve, no_posible_transition: @no_posible_transition, no_possible_transition_msg: @no_possible_transition_msg %>
+    <%= render "_moderator_pannel.html", report: @report, author: @report.author%>
 <% end%>
 
 

--- a/lib/hexpm_web/templates/package_report/show.html.eex
+++ b/lib/hexpm_web/templates/package_report/show.html.eex
@@ -8,6 +8,8 @@
 <p> <%= @report.description %>
 <p> Report status: <%= @report.state %>
 
-<%= if @to_moderator do %>
-    <%= render "_moderator_pannel.html", report_id: @report.id, author: @report.author %>
+<%= if @for_moderator do %>
+    <%= render "_moderator_pannel.html", report_id: @report.id, author: @report.author, show_accept: @show_accept, show_reject: @show_reject, show_solve: @show_solve, no_posible_transition: @no_posible_transition, no_possible_transition_msg: @no_possible_transition_msg %>
 <% end%>
+
+


### PR DESCRIPTION
Interface displays controls for moderators only.
Only controls to change to an available state are displayed.
Appropiate message is displayed when there are no available states
to update the report to.

Report state change is validated on controller, as well as if
the action is beeing performed by a moderator.