### PR TITLE
Notify users about actions on package reports (email)

### DIFF
--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -138,6 +138,14 @@ defmodule Hexpm.Accounts.User do
     )
   end
 
+  def get_by_role(role, preload \\ []) do
+    from(
+      u in Hexpm.Accounts.User,
+      where: u.role == ^role,
+      preload: ^preload
+    )
+  end
+
   def verify_permissions(%User{}, "api", _resource) do
     {:ok, nil}
   end

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -23,6 +23,12 @@ defmodule Hexpm.Accounts.Users do
     |> Repo.preload(preload)
   end
 
+  def get_by_role(role, preload \\ []) do
+    User.get_by_role(String.downcase(role))
+    |> Repo.all()
+    |> Repo.preload(preload)
+  end
+
   def get_email(email, preload \\ []) do
     Repo.get_by(Email, email: String.downcase(email))
     |> Repo.preload(preload)

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -75,14 +75,35 @@ defmodule Hexpm.Emails do
     |> render(:package_published)
   end
 
-  def report_submitted(receiver, author_name, package_name, report_id) do
+  def report_submitted(receiver, author_name, package_name, report_id, inserted_at) do
     email()
     |> email_to(receiver)
     |> subject("Hex.pm - Package report on #{package_name} published ")
-    |> assign(:package, package_name)
-    |> assign(:user, author_name)
+    |> assign(:package_name, package_name)
+    |> assign(:author_name, author_name)
     |> assign(:report_id, report_id)
+    |> assign(:inserted_at, inserted_at)
     |> render(:report_submitted)
+  end
+
+  def report_commented(receiver, author_name, report_id, inserted_at) do
+    email()
+    |> email_to(receiver)
+    |> subject("Hex.pm - New comment on package report ##{report_id}")
+    |> assign(:author_name, author_name)
+    |> assign(:report_id, report_id)
+    |> assign(:inserted_at, inserted_at)
+    |> render(:report_commented)
+  end
+
+  def report_state_changed(receiver, report_id, new_state, updated_at) do
+    email()
+    |> email_to(receiver)
+    |> subject("Hex.pm - Package report ##{report_id} has been reviewed by a moderator")
+    |> assign(:report_id, report_id)
+    |> assign(:new_state, new_state)
+    |> assign(:updated_at, updated_at)
+    |> render(:report_state_changed)
   end
 
   defp email_to(email, to) do

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -75,6 +75,16 @@ defmodule Hexpm.Emails do
     |> render(:package_published)
   end
 
+  def report_submitted(receiver, author_name, package_name, report_id) do
+    email()
+    |> email_to(receiver)
+    |> subject("Hex.pm - Package report on #{package_name} published ")
+    |> assign(:package, package_name)
+    |> assign(:user, author_name)
+    |> assign(:report_id, report_id)
+    |> render(:report_submitted)
+  end
+
   defp email_to(email, to) do
     to =
       to

--- a/lib/hexpm/repository/package_reports.ex
+++ b/lib/hexpm/repository/package_reports.ex
@@ -43,18 +43,13 @@ defmodule Hexpm.Repository.PackageReports do
 
     report = PackageReport.get(report_id)
 
-    report =
-      PackageReport.get(report_id)
-      |> Repo.one()
+    report = Repo.one(PackageReport.get(report_id))
 
     email_user_about_state_change(report, report.author)
 
     Enum.each(
-      Owners.all(report.package),
-      fn owner ->
-        owner = Hexpm.Repo.preload(owner, user: [])
-        email_user_about_state_change(report, owner.user)
-      end
+      Owners.all(report.package, user: []),
+      &email_user_about_state_change(report, &1.user)
     )
 
     Enum.each(
@@ -76,14 +71,6 @@ defmodule Hexpm.Repository.PackageReports do
       |> Repo.one()
 
     email_user_about_state_change(report, report.author)
-
-    Enum.each(
-      Owners.all(report.package),
-      fn owner ->
-        owner = Hexpm.Repo.preload(owner, user: [])
-        email_user_about_state_change(report, owner.user)
-      end
-    )
 
     Enum.each(
       Users.get_by_role("moderator"),

--- a/lib/hexpm/repository/package_reports.ex
+++ b/lib/hexpm/repository/package_reports.ex
@@ -121,9 +121,7 @@ defmodule Hexpm.Repository.PackageReports do
   def new_comment(params) do
     comment = Repo.insert!(PackageReportComment.build(params["report"], params["author"], params))
     comment = Hexpm.Repo.preload(comment, :report)
-    author = comment.report.author
-
-    email_user_about_new_comment(comment, author)
+    email_user_about_new_comment(comment, comment.report.author)
 
     Enum.each(
       Owners.all(comment.report.package),

--- a/lib/hexpm/repository/package_reports.ex
+++ b/lib/hexpm/repository/package_reports.ex
@@ -13,14 +13,6 @@ defmodule Hexpm.Repository.PackageReports do
       )
 
     Enum.each(
-      Owners.all(Kernel.elem(package_report, 1).package),
-      fn owner ->
-        owner = Hexpm.Repo.preload(owner, user: [])
-        email_user_about_new_report(package_report, owner.user)
-      end
-    )
-
-    Enum.each(
       Users.get_by_role("moderator"),
       fn user ->
         email_user_about_new_report(package_report, user)

--- a/lib/hexpm/repository/package_reports.ex
+++ b/lib/hexpm/repository/package_reports.ex
@@ -119,8 +119,8 @@ defmodule Hexpm.Repository.PackageReports do
   end
 
   def new_comment(params) do
-    comment = Repo.insert(PackageReportComment.build(params["report"], params["author"], params))
-    comment = Hexpm.Repo.preload(Kernel.elem(comment, 1), report: [])
+    comment = Repo.insert!(PackageReportComment.build(params["report"], params["author"], params))
+    comment = Hexpm.Repo.preload(comment, :report)
     author = comment.report.author
 
     email_user_about_new_comment(comment, author)

--- a/lib/hexpm/repository/package_reports.ex
+++ b/lib/hexpm/repository/package_reports.ex
@@ -38,15 +38,12 @@ defmodule Hexpm.Repository.PackageReports do
     |> Repo.one()
     |> PackageReport.change_state(%{"state" => "accepted"})
     |> Repo.update()
+
     report = Repo.one(PackageReport.get(report_id))
 
     Enum.each(
-      Owners.all(report.package, user: []),
-      &email_user_about_state_change(report, &1.user)
-    )
-
-    Enum.each(
-      [report.author] ++ Users.get_by_role("moderator"),
+      Enum.map(Owners.all(report.package, user: []), & &1.user) ++
+        [report.author] ++ Users.get_by_role("moderator"),
       &email_user_about_state_change(report, &1)
     )
   end
@@ -76,13 +73,8 @@ defmodule Hexpm.Repository.PackageReports do
     report = Repo.one(PackageReport.get(report_id))
 
     Enum.each(
-      Owners.all(report.package, user: []),
+      Enum.map(Owners.all(report.package, user: []), & &1.user) ++ Users.get_by_role("moderator"),
       &email_user_about_state_change(report, &1.user)
-    )
-
-    Enum.each(
-      Users.get_by_role("moderator"),
-      &email_user_about_state_change(report, &1)
     )
   end
 
@@ -91,12 +83,8 @@ defmodule Hexpm.Repository.PackageReports do
     comment = Hexpm.Repo.preload(Kernel.elem(comment, 1), report: [])
 
     Enum.each(
-      Owners.all(comment.report.package, user: []),
-      &email_user_about_new_comment(comment, &1.user)
-    )
-
-    Enum.each(
-      [comment.report.author] ++ Users.get_by_role("moderator"),
+      Enum.map(Owners.all(comment.report.package, user: []), & &1.user) ++
+        [comment.report.author] ++ Users.get_by_role("moderator"),
       &email_user_about_new_comment(comment, &1)
     )
   end

--- a/lib/hexpm/repository/package_reports.ex
+++ b/lib/hexpm/repository/package_reports.ex
@@ -12,12 +12,7 @@ defmodule Hexpm.Repository.PackageReports do
         )
       )
 
-    Enum.each(
-      Users.get_by_role("moderator"),
-      fn user ->
-        email_user_about_new_report(package_report, user)
-      end
-    )
+    Enum.each(Users.get_by_role("moderator"), &email_user_about_new_report(package_report, &1))
   end
 
   def all() do

--- a/lib/hexpm_web/controllers/package_report_controller.ex
+++ b/lib/hexpm_web/controllers/package_report_controller.ex
@@ -91,7 +91,7 @@ defmodule HexpmWeb.PackageReportController do
     for_author = user.id == report.author.id
     for_basic = not (for_moderator or for_owner or for_author)
 
-    if report == nil or (report.state == "to_accept" and (for_owner or for_basic)) or
+    if report == nil or (report.state == "to_accept" and (for_owner and not (for_moderator or for_author))) or
          (report.state not in ["to_accept", "solved"] and for_basic) do
       conn
       |> put_flash(:error, @report_not_accessible)

--- a/lib/hexpm_web/controllers/package_report_controller.ex
+++ b/lib/hexpm_web/controllers/package_report_controller.ex
@@ -91,7 +91,8 @@ defmodule HexpmWeb.PackageReportController do
     for_author = user.id == report.author.id
     for_basic = not (for_moderator or for_owner or for_author)
 
-    if report == nil or (report.state == "to_accept" and (for_owner and not (for_moderator or for_author))) or
+    if report == nil or
+         (report.state == "to_accept" and (for_owner and not (for_moderator or for_author))) or
          (report.state not in ["to_accept", "solved"] and for_basic) do
       conn
       |> put_flash(:error, @report_not_accessible)

--- a/lib/hexpm_web/templates/email/report_commented.html.eex
+++ b/lib/hexpm_web/templates/email/report_commented.html.eex
@@ -1,0 +1,1 @@
+<p> <%= @author_name %> wrote a comment on report with id <%= @report_id %> at <%= @inserted_at %> </p>

--- a/lib/hexpm_web/templates/email/report_commented.text.eex
+++ b/lib/hexpm_web/templates/email/report_commented.text.eex
@@ -1,0 +1,1 @@
+<%= @author_name %> wrote a comment on report with id <%= @report_id %> at <%= @inserted_at %>

--- a/lib/hexpm_web/templates/email/report_state_changed.html.eex
+++ b/lib/hexpm_web/templates/email/report_state_changed.html.eex
@@ -1,0 +1,3 @@
+<p> A moderator modified the package report #<%= @report_id %> state to <%= @new_state%> at <%= @updated_at %>.</p>
+
+<p><%= ReportState.state_explain(@new_state) %></p>

--- a/lib/hexpm_web/templates/email/report_state_changed.text.eex
+++ b/lib/hexpm_web/templates/email/report_state_changed.text.eex
@@ -1,0 +1,3 @@
+A moderator modified the package report #<%= @report_id %> state to <%= @new_state%> at <%= @updated_at %>.
+
+<%= ReportState.state_explain(@new_state) %>

--- a/lib/hexpm_web/templates/email/report_submitted.html.eex
+++ b/lib/hexpm_web/templates/email/report_submitted.html.eex
@@ -1,1 +1,5 @@
-<p> A new report has been submited</p>
+<p> <%= @author_name %> submitted a report on <%= @package_name %> package at <%= @inserted_at %>.</p>
+
+<p> The report id is <%= @report_id %>. <p>
+
+<p><%= ReportState.state_explain("to_accept") %></p>

--- a/lib/hexpm_web/templates/email/report_submitted.html.eex
+++ b/lib/hexpm_web/templates/email/report_submitted.html.eex
@@ -1,0 +1,1 @@
+<p> A new report has been submited</p>

--- a/lib/hexpm_web/templates/email/report_submitted.text.eex
+++ b/lib/hexpm_web/templates/email/report_submitted.text.eex
@@ -1,1 +1,5 @@
-A new report has been submited
+<%= @author_name %> submitted a report on <%= @package_name %> package at <%= @inserted_at %>.
+
+The report id is <%= @report_id %>.
+
+<%= ReportState.state_explain("to_accept") %>

--- a/lib/hexpm_web/templates/email/report_submitted.text.eex
+++ b/lib/hexpm_web/templates/email/report_submitted.text.eex
@@ -1,0 +1,1 @@
+A new report has been submited

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -110,6 +110,7 @@ defmodule HexpmWeb.EmailView do
       Only the report author and moderators can see the report description.
       """
     end
+
     def state_explain("accepted") do
       """
       The report has now state \"accepted\".

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -101,4 +101,37 @@ defmodule HexpmWeb.EmailView do
       """
     end
   end
+
+  defmodule ReportState do
+    def state_explain("to_accept") do
+      """
+      The report has now state \"to_accept\".
+      This means that the vulnerability reported has to be reviewed by a moderator in order to be recognized or not as a real vulnerability.
+      Only the report author and moderators can see the report description.
+      """
+    end
+    def state_explain("accepted") do
+      """
+      The report has now state \"accepted\".
+      This means that the vulnerability reported has been recognized by a moderator as real.
+      A comments section has been enabled on the report for moderators, owners and the report author to discuss the vulnerability.
+      """
+    end
+
+    def state_explain("solved") do
+      """
+      The report has now state \"solved\".
+      This means that the vulnerability reported has been solved.
+      Now the report is public, so users other than the report author, moderators and the reported package owners can read the report description.
+      """
+    end
+
+    def state_explain("rejected") do
+      """
+      The report has now state \"rejected\".
+      This means that the vulnerability reported has not been recognized as such a vulnerability by a moderator.
+      The report will not be made public, so users other than the report author, moderators and the reported package owners will not be able to read the report description or the comments section.
+      """
+    end
+  end
 end


### PR DESCRIPTION
The following subjects had been considered.
1) Report has new comments
2) Report state changed
3) New reports to be reviewed
4) Report on package has been submitted
Since moderators are notified when a new report is submitted the 3rd subject has been discarded.

When a report is submitted owners and moderators are notified. Report author is not since he/she 's already aware of the report being published.
For the moment report author, moderators and package owners are notified when a report is accepted, solved or rejected.